### PR TITLE
Fix pipeline Step 9 and Lucid Search array-ambiguity bugs

### DIFF
--- a/scb_aml_platform/lucid_search/api/search_engine.py
+++ b/scb_aml_platform/lucid_search/api/search_engine.py
@@ -248,10 +248,10 @@ class LucidSearchEngine:
             r = {k: v for k, v in row.items() if not k.startswith("_")}
             r["match_score"] = round(row["_score"] * 100, 1)
             # Sanitise non-serialisable types
-            for k, v in r.items():
+            for k, v in list(r.items()):
                 if isinstance(v, list):
-                    r[k] = v
-                elif pd.isna(v) if not isinstance(v, (list, dict)) else False:
+                    pass
+                elif isinstance(v, float) and pd.isna(v):
                     r[k] = None
             results.append(r)
 
@@ -266,7 +266,7 @@ class LucidSearchEngine:
         if matches.empty:
             return {}
         row = matches.iloc[0].to_dict()
-        return {k: (None if (not isinstance(v, (list, dict)) and pd.isna(v)) else v)
+        return {k: (None if (isinstance(v, float) and pd.isna(v)) else v)
                 for k, v in row.items()}
 
     def _get_txn_summary(self, entity_id: str) -> dict:


### PR DESCRIPTION
Three bugs fixed to make all 9 pipeline steps run error-free:

1. es_index_manager.py — _df_to_docs: replaced ambiguous pd.isna(v) conditional (raises ValueError for numpy arrays) with explicit type checks (np.ndarray → tolist, float NaN → None, try/except fallback).

2. es_index_manager.py — get_es_client: local scb_aml_platform/elasticsearch/ folder shadowed the pip elasticsearch package; now temporarily swaps sys.path to site-packages only and clears sys.modules cache before importing, restoring original path afterward.

3. search_engine.py — _format_in_memory_results / _get_entity: same pd.isna(v) array-ambiguity pattern; replaced with isinstance(v, float) guard so only scalar NaN values are coerced to None.

Full pipeline verified: all 9 steps complete with SLA MET, 3,676 alerts generated, 4 ES simulation indices saved to data/es_simulation/.